### PR TITLE
Bump version for SDK packages

### DIFF
--- a/Modules/Common/Common.csproj
+++ b/Modules/Common/Common.csproj
@@ -15,12 +15,12 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="CDP4Common-CE" Version="6.3.0" />
-    <PackageReference Include="CDP4Dal-CE" Version="6.3.0" />
-    <PackageReference Include="CDP4JsonFileDal-CE" Version="6.3.0" />
+    <PackageReference Include="CDP4Dal-CE" Version="7.0.0" />
+    <PackageReference Include="CDP4JsonFileDal-CE" Version="7.0.0" />
     <PackageReference Include="CDP4JsonSerializer-CE" Version="6.3.0" />
     <PackageReference Include="CDP4Rules-CE" Version="6.3.0" />
-    <PackageReference Include="CDP4ServicesDal-CE" Version="6.3.0" />
-    <PackageReference Include="CDP4WspDal-CE" Version="6.3.0" />
+    <PackageReference Include="CDP4ServicesDal-CE" Version="7.0.0" />
+    <PackageReference Include="CDP4WspDal-CE" Version="7.0.0" />
     <PackageReference Include="DevExpress.CodeParser" Version="20.1.8" />
     <PackageReference Include="DevExpress.Data" Version="20.1.8" />
     <PackageReference Include="DevExpress.Data.Desktop" Version="20.1.8" />

--- a/Modules/Migration.Tests/Migration.Tests.csproj
+++ b/Modules/Migration.Tests/Migration.Tests.csproj
@@ -23,11 +23,11 @@
   <ItemGroup>
     <PackageReference Include="Castle.Core" Version="4.4.0" />
     <PackageReference Include="CDP4Common-CE" Version="6.3.0" />
-    <PackageReference Include="CDP4Dal-CE" Version="6.3.0" />
-    <PackageReference Include="CDP4JsonFileDal-CE" Version="6.3.0" />
+    <PackageReference Include="CDP4Dal-CE" Version="7.0.0" />
+    <PackageReference Include="CDP4JsonFileDal-CE" Version="7.0.0" />
     <PackageReference Include="CDP4JsonSerializer-CE" Version="6.3.0" />
-    <PackageReference Include="CDP4ServicesDal-CE" Version="6.3.0" />
-    <PackageReference Include="CDP4WspDal-CE" Version="6.3.0" />
+    <PackageReference Include="CDP4ServicesDal-CE" Version="7.0.0" />
+    <PackageReference Include="CDP4WspDal-CE" Version="7.0.0" />
     <PackageReference Include="DotNetZip" Version="1.13.8" />
     <PackageReference Include="Microsoft.AspNet.WebApi.Client" Version="5.2.7" />
     <PackageReference Include="Microsoft.Bcl" Version="1.1.10" />

--- a/Modules/Migration/Migration.csproj
+++ b/Modules/Migration/Migration.csproj
@@ -18,12 +18,12 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="CDP4Common-CE" Version="6.3.0" />
-    <PackageReference Include="CDP4Dal-CE" Version="6.3.0" />
-    <PackageReference Include="CDP4JsonFileDal-CE" Version="6.3.0" />
+    <PackageReference Include="CDP4Dal-CE" Version="7.0.0" />
+    <PackageReference Include="CDP4JsonFileDal-CE" Version="7.0.0" />
     <PackageReference Include="CDP4JsonSerializer-CE" Version="6.3.0" />
     <PackageReference Include="CDP4Rules-CE" Version="6.3.0" />
-    <PackageReference Include="CDP4ServicesDal-CE" Version="6.3.0" />
-    <PackageReference Include="CDP4WspDal-CE" Version="6.3.0" />
+    <PackageReference Include="CDP4ServicesDal-CE" Version="7.0.0" />
+    <PackageReference Include="CDP4WspDal-CE" Version="7.0.0" />
     <PackageReference Include="DevExpress.CodeParser" Version="20.1.8" />
     <PackageReference Include="DevExpress.Data" Version="20.1.8" />
     <PackageReference Include="DevExpress.Data.Desktop" Version="20.1.8" />

--- a/Modules/StressGenerator/StressGenerator.csproj
+++ b/Modules/StressGenerator/StressGenerator.csproj
@@ -26,12 +26,12 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="CDP4Common-CE" Version="6.3.0" />
-    <PackageReference Include="CDP4Dal-CE" Version="6.3.0" />
-    <PackageReference Include="CDP4JsonFileDal-CE" Version="6.3.0" />
+    <PackageReference Include="CDP4Dal-CE" Version="7.0.0" />
+    <PackageReference Include="CDP4JsonFileDal-CE" Version="7.0.0" />
     <PackageReference Include="CDP4JsonSerializer-CE" Version="6.3.0" />
     <PackageReference Include="CDP4Rules-CE" Version="6.3.0" />
-    <PackageReference Include="CDP4ServicesDal-CE" Version="6.3.0" />
-    <PackageReference Include="CDP4WspDal-CE" Version="6.3.0" />
+    <PackageReference Include="CDP4ServicesDal-CE" Version="7.0.0" />
+    <PackageReference Include="CDP4WspDal-CE" Version="7.0.0" />
     <PackageReference Include="DevExpress.CodeParser" Version="20.1.8" />
     <PackageReference Include="DevExpress.Data" Version="20.1.8" />
     <PackageReference Include="DevExpress.Data.Desktop" Version="20.1.8" />

--- a/Modules/Syncer.Tests/Syncer.Tests.csproj
+++ b/Modules/Syncer.Tests/Syncer.Tests.csproj
@@ -20,11 +20,11 @@
   <ItemGroup>
     <PackageReference Include="Castle.Core" Version="4.4.0" />
     <PackageReference Include="CDP4Common-CE" Version="6.3.0" />
-    <PackageReference Include="CDP4Dal-CE" Version="6.3.0" />
-    <PackageReference Include="CDP4JsonFileDal-CE" Version="6.3.0" />
+    <PackageReference Include="CDP4Dal-CE" Version="7.0.0" />
+    <PackageReference Include="CDP4JsonFileDal-CE" Version="7.0.0" />
     <PackageReference Include="CDP4JsonSerializer-CE" Version="6.3.0" />
-    <PackageReference Include="CDP4ServicesDal-CE" Version="6.3.0" />
-    <PackageReference Include="CDP4WspDal-CE" Version="6.3.0" />
+    <PackageReference Include="CDP4ServicesDal-CE" Version="7.0.0" />
+    <PackageReference Include="CDP4WspDal-CE" Version="7.0.0" />
     <PackageReference Include="DotNetZip" Version="1.13.8" />
     <PackageReference Include="Microsoft.AspNet.WebApi.Client" Version="5.2.7" />
     <PackageReference Include="Microsoft.Bcl" Version="1.1.10" />

--- a/Modules/Syncer/Syncer.csproj
+++ b/Modules/Syncer/Syncer.csproj
@@ -15,7 +15,10 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="CDP4Common-CE" Version="6.3.0" />
-    <PackageReference Include="CDP4Dal-CE" Version="6.3.0" />
+    <PackageReference Include="CDP4Dal-CE" Version="7.0.0" />
+    <PackageReference Include="CDP4JsonFileDal-CE" Version="7.0.0" />
+    <PackageReference Include="CDP4ServicesDal-CE" Version="7.0.0" />
+    <PackageReference Include="CDP4WspDal-CE" Version="7.0.0" />
     <PackageReference Include="DevExpress.CodeParser" Version="20.1.8" />
     <PackageReference Include="DevExpress.Data" Version="20.1.8" />
     <PackageReference Include="DevExpress.Data.Desktop" Version="20.1.8" />

--- a/SAT/SAT.csproj
+++ b/SAT/SAT.csproj
@@ -25,12 +25,12 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="CDP4Common-CE" Version="6.3.0" />
-    <PackageReference Include="CDP4Dal-CE" Version="6.3.0" />
-    <PackageReference Include="CDP4JsonFileDal-CE" Version="6.3.0" />
+    <PackageReference Include="CDP4Dal-CE" Version="7.0.0" />
+    <PackageReference Include="CDP4JsonFileDal-CE" Version="7.0.0" />
     <PackageReference Include="CDP4JsonSerializer-CE" Version="6.3.0" />
     <PackageReference Include="CDP4Rules-CE" Version="6.3.0" />
-    <PackageReference Include="CDP4ServicesDal-CE" Version="6.3.0" />
-    <PackageReference Include="CDP4WspDal-CE" Version="6.3.0" />
+    <PackageReference Include="CDP4ServicesDal-CE" Version="7.0.0" />
+    <PackageReference Include="CDP4WspDal-CE" Version="7.0.0" />
     <PackageReference Include="CommonServiceLocator" Version="1.3" />
     <PackageReference Include="DevExpress.CodeParser" Version="20.1.8" />
     <PackageReference Include="DevExpress.Data" Version="20.1.8" />


### PR DESCRIPTION
Bump version for the next SDK packages: CDP4Dal-CE, CDP4JsonFileDal-CE, CDP4ServicesDal-CE, CDP4WspDal-CE.

### Prerequisites

- [X] I have written a descriptive pull-request title
- [X] I have verified that there are no overlapping [pull-requests](https://github.com/RHEAGROUP/CDP4-Server-Administration-Tool/pulls) open
- [X] I have verified that I am following the CDP4-Server-Administration-Tool [code style guidelines](https://raw.githubusercontent.com/RHEAGROUP/CDP4-Server-Administration-Tool/master/.github/CONTRIBUTING.md)
- [X] I have provided test coverage for my change (where applicable)